### PR TITLE
CSRF Security Patching

### DIFF
--- a/sign_up.html
+++ b/sign_up.html
@@ -35,6 +35,7 @@
             <p id="error-message" class="hidden"></p>
 
             <form action="signup.php" method="POST">
+                <input type="hidden" name="csrf_token" value="<?php echo $_SESSION['csrf_token']; ?>">
                 <div>
                     <input type="text" name="fullname" placeholder="Full Name" required>
                 </div>

--- a/signup.php
+++ b/signup.php
@@ -1,9 +1,20 @@
 <?php
+// Setting secure session cookie settings
+session_set_cookie_params([
+    'httponly' => true,
+    'samesite' => 'Strict' // Prevents CSRF attacks by restricting cross-site cookie usage
+]);
+
 session_start();
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 
 require 'db.php'; // Ensure db.php is correct
+
+// Generate CSRF token if it doesn't exist
+if (!isset($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
 
 $cooldown_time = 15; // Cooldown is set to 15 seconds. In a real-scenario this would be set much higher, however this is just for testing.
 $current_time = time();
@@ -20,9 +31,14 @@ if ($current_time - $_SESSION['last_successful_signup'] < $cooldown_time) {
 }
 
 if ($_SERVER["REQUEST_METHOD"] == "POST") {
+    // Validate CSRF token
+    if (!isset($_POST['csrf_token']) || $_POST['csrf_token'] !== $_SESSION['csrf_token']) {
+        die("CSRF validation failed!");
+    }
+
     // Prevent XSS by sanitising input
     $fullname = htmlspecialchars($_POST['fullname'], ENT_QUOTES, 'UTF-8');
-    $email = htmlspecialchars($_POST['email'], ENT_QUOTES, 'UTF-8');
+    $email = filter_var($_POST['email'], FILTER_SANITIZE_EMAIL);
     $password = $_POST['password'];
 
     // Hash the password for security
@@ -49,7 +65,10 @@ if ($_SERVER["REQUEST_METHOD"] == "POST") {
         $stmt->bind_param("sss", $fullname, $email, $hashed_password);
         if ($stmt->execute()) {
             // Apply signup cooldown
-            $_SESSION['last_successful_signup'] = $current_time; // Set the session time now            
+            $_SESSION['last_successful_signup'] = $current_time; // Set the session time now  
+            
+            // Regenerates CSRF token after successful signup
+            $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 
             // ✅ Redirect to login page after successful signup
             header("Location: log_in.html");


### PR DESCRIPTION
Fixing Cross-Site Request Forgery (CSRF) Vulnerabilities - Security Issue #10, where: Due to lack of CSRF tokens, the application is currently vulnerable to Cross-Site Request Forgery (CSRF) attacks.

Solved by: session_set_cookie_params() is set to ensure the session cookie is HTTPOnly and uses the Strict SameSite policy. This prevents CSRF attacks, making the session cookie less vulnerable to client-side JavaScript access. Also, CSRF token generation and validation is implemented, checking the token both in the session and the form, which prevents unauthorised requests. After successful signup, the CSRF token is regenerated.