### PR TITLE
Automatic Table Creation

### DIFF
--- a/includes/dbh.inc.php
+++ b/includes/dbh.inc.php
@@ -1,9 +1,30 @@
 <?php
-// Connect to database
-$dbconnection = new mysqli("localhost", "", "", "db"); // To connect to database please refer to 'filezilla_connection.txt' on Basecamp
+// To connect to database please refer to 'filezilla_connection.txt' on Basecamp
+$servername = "localhost"; // KEEP "localhost"
+$username = "";  // YOUR_STUDENT_NUMBER
+$password = "";      // YOUR_MYSQL_PASSWORD
+$dbname = "";  // db[YOUR_STUDENT_ID]
+
+// Create connection to the database
+$dbconnection = new mysqli($servername, $username, $password, $dbname);
 
 // Check connection
 if ($dbconnection->connect_error) {
     die("Connection failed: " . $dbconnection->connect_error);
 }
+
+// Create the table if it doesn't exist already
+$table_sql = "CREATE TABLE IF NOT EXISTS openday_user_info (
+    UID INT AUTO_INCREMENT PRIMARY KEY,
+    fullName VARCHAR(255) NOT NULL,
+    userEmail VARCHAR(255) NOT NULL UNIQUE,
+    userPassword VARCHAR(255) NOT NULL
+)";
+
+if ($dbconnection->query($table_sql) === TRUE) {
+    echo "Table 'openday_user_info' created successfully.";
+} else {
+    die("Error creating table: " . $dbconnection->error);
+}
+
 ?>


### PR DESCRIPTION
Solving GitHub issue "Automatic Table Creation #21", where: As the database we are using is on MI-Linux and there is not 1 central database, but the database is localhosted and unique to the user, the tables have to be manually created to store information for forms such as signup and login. Instead of having to manually create these tables we can automate this process.

I have kept the initial database connection, as the database itself is always created, and added a query to check if the table to store user information already exists, and if not then this table is created.

Automatic table creation like this is fine for our project as we are working in a local development environment, however in industry, we would not be using localhosted databases but one central so this problem would be avoided. For our project, this simply saves time having to manually create the table on the database, providing better ease of access.